### PR TITLE
provide decode_int{32,64}(...)

### DIFF
--- a/bson/codec.py
+++ b/bson/codec.py
@@ -309,16 +309,24 @@ def decode_none_element(data, base):
 def encode_int32_element(name, value):
 	return "\x10" + encode_cstring(name) + struct.pack("<i", value)
 
+def decode_int32(data, base):
+	value = struct.unpack("<i", data[base:base + 4])[0]
+	return base + 4, value
+
 def decode_int32_element(data, base):
 	base, name = decode_cstring(data, base + 1)
-	value = struct.unpack("<i", data[base:base + 4])[0]
-	return (base + 4, name, value)
+	base_new, value = decode_int64(data,base)
+	return (base_new, name, value)
 
 def encode_int64_element(name, value):
 	return "\x12" + encode_cstring(name) + struct.pack("<q", value)
 
+def decode_int64(data, base):
+	value = struct.unpack("<q", data[base:base + 8])[0]
+	return base + 8, value
+
 def decode_int64_element(data, base):
 	base, name = decode_cstring(data, base + 1)
-	value = struct.unpack("<q", data[base:base + 8])[0]
-	return (base + 8, name, value)
+	base_new, value = decode_int64(data,base)
+	return (base_new, name, value)
 # }}}

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from setuptools import setup, find_packages
 
 setup(name = "bson",
-		version="0.3.3dev1",
+		version="0.3.3",
 		packages=["bson"],
 		install_requires = ["pytz>=2010b"],
 		author = "Kou Man Tong",


### PR DESCRIPTION
in addition to decode_int_element{32,64}(...) this commit provides
decode_int{32,64}(...).

i modified decode_int_element{32,64}(...) to then use these new methods, so that no code doubling is introduced.

this suits the fact that there are already functions like decode_cstring() which are very useful for raw bson io.