### PR TITLE
encode_cstring fix for longs and int

### DIFF
--- a/bson/codec.py
+++ b/bson/codec.py
@@ -106,6 +106,8 @@ def decode_string(data, base):
 	return (base + 4 + length, value)
 
 def encode_cstring(value):
+	if isinstance(value, long) or isinstance(value, int):
+		value = str(value)
 	if isinstance(value, unicode):
 		value = value.encode("utf8")
 	return value + "\x00"


### PR DESCRIPTION
Hey Martin,

As I was using your bson parser in a project, I noticed it didn't handle
long type keys to well. I was given a "can't add str and long objects" error.
My data structure being:

{320L: {'title': 'testing, 'lat': 20.0, 'lng': 50.0, 'id': 320L}, 
 300L: {'title': 'testing', 'lat': 20.0, 'lng': 50.0, 'id': 300L}}


This led me to look into encode_cstring
and make the following check for long or int types.

Line 108 in encode_cstring/1:

if isinstance(value, long) or isinstance(value, int):
	value = str(value)

I have attached it in my forked version of bsonpy which I have made a pull
request on over github.

I hope I could help in anyway.

Thanks,
Nadir